### PR TITLE
[codex] add contact action icons and photo placeholder

### DIFF
--- a/Contacts.View/Contacts.View.csproj
+++ b/Contacts.View/Contacts.View.csproj
@@ -15,6 +15,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Resource Include="Assets\*.png" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\Contacts.Model\Contacts.Model.csproj" />
     <ProjectReference Include="..\Contacts.ViewModel\Contacts.ViewModel.csproj" />
   </ItemGroup>

--- a/Contacts.View/Controls/ContactControl.xaml
+++ b/Contacts.View/Controls/ContactControl.xaml
@@ -31,15 +31,40 @@
     </Grid.ColumnDefinitions>
 
     <!-- Фото контакта -->
-    <Image
+    <Grid
       Grid.Column="0"
       Width="100"
       Height="100"
       VerticalAlignment="Top"
       Margin="0,0,12,0"
-      Source="/Assets/photo_placeholder_100x100.png"
-      Stretch="Uniform"
-    />
+    >
+      <Border
+        BorderBrush="#FFD0D0D0"
+        BorderThickness="1"
+        Background="#FFF8F8F8"
+      />
+      <Image
+        Source="pack://application:,,,/Assets/photo_placeholder_100x100.png"
+        Stretch="Uniform"
+      />
+      <Border
+        Width="28"
+        Height="28"
+        HorizontalAlignment="Right"
+        VerticalAlignment="Bottom"
+        Margin="0,0,3,3"
+        Background="White"
+        BorderBrush="#FFD0D0D0"
+        BorderThickness="1"
+      >
+        <Image
+          Width="18"
+          Height="18"
+          Source="pack://application:,,,/Assets/add_photo_32x32.png"
+          ToolTip="Фото контакта"
+        />
+      </Border>
+    </Grid>
 
     <!-- Поля контакта -->
     <StackPanel Grid.Column="1">

--- a/Contacts.View/MainWindow.xaml
+++ b/Contacts.View/MainWindow.xaml
@@ -16,6 +16,12 @@
   <Window.Resources>
     <!-- Конвертер для видимости кнопки Apply -->
     <converters:VisibilityConverter x:Key="VisibilityConverter" />
+    <Style x:Key="ActionButtonStyle" TargetType="Button">
+      <Setter Property="Height" Value="25" />
+      <Setter Property="Padding" Value="6,0" />
+      <Setter Property="VerticalContentAlignment" Value="Center" />
+      <Setter Property="HorizontalContentAlignment" Value="Center" />
+    </Style>
     <!-- Шаблон элемента списка контактов -->
     <DataTemplate x:Key="ContactTemplate">
       <StackPanel Margin="3">
@@ -58,31 +64,55 @@
           Margin="0,0,0,8"
         />
         <!-- Кнопки управления -->
-        <StackPanel Grid.Row="2" Orientation="Horizontal">
+        <UniformGrid Grid.Row="2" Columns="3">
           <Button
-            Content="Add"
             Command="{Binding AddCommand}"
-            Width="Auto"
-            Height="25"
             Margin="0,0,3,0"
-            Padding="10,0"
-          />
+            Style="{StaticResource ActionButtonStyle}"
+            ToolTip="Добавить контакт"
+          >
+            <StackPanel Orientation="Horizontal">
+              <Image
+                Width="16"
+                Height="16"
+                Margin="0,0,4,0"
+                Source="pack://application:,,,/Assets/add_contact_32x32.png"
+              />
+              <TextBlock Text="Add" />
+            </StackPanel>
+          </Button>
           <Button
-            Content="Edit"
             Command="{Binding EditCommand}"
-            Width="Auto"
-            Height="25"
             Margin="0,0,3,0"
-            Padding="10,0"
-          />
+            Style="{StaticResource ActionButtonStyle}"
+            ToolTip="Редактировать контакт"
+          >
+            <StackPanel Orientation="Horizontal">
+              <Image
+                Width="16"
+                Height="16"
+                Margin="0,0,4,0"
+                Source="pack://application:,,,/Assets/edit_contact_32x32.png"
+              />
+              <TextBlock Text="Edit" />
+            </StackPanel>
+          </Button>
           <Button
-            Content="Remove"
             Command="{Binding RemoveCommand}"
-            Width="Auto"
-            Height="25"
-            Padding="10,0"
-          />
-        </StackPanel>
+            Style="{StaticResource ActionButtonStyle}"
+            ToolTip="Удалить контакт"
+          >
+            <StackPanel Orientation="Horizontal">
+              <Image
+                Width="16"
+                Height="16"
+                Margin="0,0,4,0"
+                Source="pack://application:,,,/Assets/remove_contact_32x32.png"
+              />
+              <TextBlock Text="Remove" />
+            </StackPanel>
+          </Button>
+        </UniformGrid>
       </Grid>
     </Grid>
     <!-- GridSplitter - разделитель -->
@@ -116,13 +146,24 @@
         <!-- Кнопка Apply -->
         <Button
           Grid.Row="3"
-          Content="Apply"
           Command="{Binding ApplyCommand}"
           Visibility="{Binding IsApplyVisible, Converter={StaticResource VisibilityConverter}}"
           Width="75"
           Height="25"
           HorizontalAlignment="Left"
-        />
+          Style="{StaticResource ActionButtonStyle}"
+          ToolTip="Применить изменения"
+        >
+          <StackPanel Orientation="Horizontal">
+            <Image
+              Width="16"
+              Height="16"
+              Margin="0,0,4,0"
+              Source="pack://application:,,,/Assets/collapse_32x32.png"
+            />
+            <TextBlock Text="Apply" />
+          </StackPanel>
+        </Button>
       </Grid>
     </Grid>
   </Grid>


### PR DESCRIPTION
﻿## Summary
- add icons from Assets to Add, Edit, Remove, and Apply actions
- make the contact photo placeholder explicit with a 100x100 framed block
- embed PNG assets as WPF resources so pack URIs resolve at runtime

## Why
This polishes the contact editor layout for the lab mockup while keeping the behavior unchanged.

## Validation
- dotnet build
